### PR TITLE
Closes #33

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ pandas==2.1.*
 duckdb==0.10.1
 click==8.1.*
 pyarrow==15.0.2
-adbc-driver-flightsql==0.10.*
-adbc-driver-manager==0.10.*
+adbc-driver-flightsql==0.11.*
+adbc-driver-manager==0.11.*


### PR DESCRIPTION
Allows quoted semi-colons in the `--init-sql-commands` string.  Upgrades ADBC Python drivers to `0.11.0`.